### PR TITLE
feat: add patient card component

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,17 +6,20 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { LoginComponent } from './login/login.component';
+import { MatDividerModule } from '@angular/material/divider';
 
 import { MatCardModule } from '@angular/material/card';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-
+import { PatientCardComponent } from './patient-card/patient-card.component';
+import { MatRippleModule } from '@angular/material/core';
 
 @NgModule({
   declarations: [
     AppComponent,
-    LoginComponent
+    LoginComponent,
+    PatientCardComponent
   ],
   imports: [
     BrowserModule,
@@ -28,6 +31,8 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
     MatButtonModule,
     ReactiveFormsModule,
     BrowserAnimationsModule,
+    MatDividerModule,
+    MatRippleModule,
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/patient-card/patient-card.component.html
+++ b/src/app/patient-card/patient-card.component.html
@@ -1,0 +1,15 @@
+<mat-card
+  matRipple
+  class="container"
+  [ngClass]="{'selected': selected}"
+  [ngStyle]="getStatusStyle()"
+>
+  <mat-card-title>Paciente n°: {{patientNumber}}</mat-card-title>
+  <mat-divider></mat-divider>
+  <mat-card-content class="content">
+    Tipo de consulta: {{description}}
+  </mat-card-content>
+  <mat-card-content>
+    Status: {{getPatientStatus()}}
+  </mat-card-content>
+</mat-card>

--- a/src/app/patient-card/patient-card.component.scss
+++ b/src/app/patient-card/patient-card.component.scss
@@ -1,0 +1,14 @@
+.container {
+  width: 280px;
+  height: 120px;
+  padding: 12px;
+  cursor: pointer;
+}
+
+.content {
+  margin-top: 16px;
+}
+
+.selected {
+  background-color: #beffba;
+}

--- a/src/app/patient-card/patient-card.component.spec.ts
+++ b/src/app/patient-card/patient-card.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PatientCardComponent } from './patient-card.component';
+
+describe('PatientCardComponent', () => {
+  let component: PatientCardComponent;
+  let fixture: ComponentFixture<PatientCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PatientCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PatientCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/patient-card/patient-card.component.ts
+++ b/src/app/patient-card/patient-card.component.ts
@@ -1,0 +1,42 @@
+import { Component, Input } from '@angular/core';
+
+type StatusId = 'waiting_line' | 'waiting_doctor' | 'waiting_definition' | 'done';
+
+const patientStatus = {
+  'waiting_line': 'Esperando na Fila',
+  'waiting_doctor': 'Aguardando Atendimento',
+  'waiting_definition': 'Aguarda Definição',
+  'done': 'Já atendido',
+} as const;
+
+const statusStyle = {
+  'waiting_line': { backgroundColor: '#FFFFFF' },
+  'waiting_doctor': { backgroundColor: '#a1a1ff' },
+  'waiting_definition': { backgroundColor: '#fffdba' },
+  'done': { backgroundColor: '#d6d6d6' },
+} as const;
+
+@Component({
+  selector: 'app-patient-card',
+  templateUrl: './patient-card.component.html',
+  styleUrls: ['./patient-card.component.scss'],
+})
+export class PatientCardComponent {
+  @Input() patientNumber = 999;
+
+  @Input() description = 'lorem ipsum something something';
+
+  @Input() selected = false;
+
+  @Input() patientStatusId: StatusId = 'done';
+
+  constructor() { }
+
+  getPatientStatus() {
+    return patientStatus[this.patientStatusId];
+  }
+
+  getStatusStyle() {
+    return statusStyle[this.patientStatusId];
+  }
+}


### PR DESCRIPTION
# Description
Create card component which will be used for simple patient identification in a list.

# Testing
You can add `<app-patient-card></app-patient-card>` to `src/app/app.component.html`.
Then serve the application with `yarn start`.

# Visual Reference
![image](https://user-images.githubusercontent.com/41351032/174403262-1003283f-9a1d-4959-96f6-1c0a7eedb215.png)
